### PR TITLE
Default to master, Allow commits to be specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,32 +47,54 @@ tf-aws-vpc:
     version: "v1.46.0"
 ```
 
-To pin a module to a specific commit, use the `commit` key:
+To pin a module to a specific `commit`:
 ```
 tf-aws-vpc-commit:
     source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
     commit: "01601169c00c68f37d5df8a80cc17c88f02c04d0"
 ```
 
+Many organizations use a mono-repo approach with all their Terraform modules
+defined in one repository. If you're in a position where all of your
+Terraform modules are in a single repo but you only require some of them, you
+can checkout a path from a Git repository.
+
+To checkout a `path` from a repository:
+```
+tf-aws-vpc-path:
+    source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+    path: "examples/simple-vpc"
+```
+
+
 Terrafile config file in current directory and modules exported to ./vendor/modules
 ```sh
 $ terrafile
-INFO[0000] [*] Checking out v1.46.0 of git@github.com:terraform-aws-modules/terraform-aws-vpc  
-INFO[0000] [*] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc  
+INFO[0000] [tf-aws-vpc-path] Checking out examples/simple-vpc from master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0002] [tf-aws-vpc] Checking out v1.46.0 of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0003] [tf-aws-vpc-experimental] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0005] [tf-aws-vpc-default] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0007] [tf-aws-vpc-commit] Checking out 01601169c00c68f37d5df8a80cc17c88f02c04d0 of git@github.com:terraform-aws-modules/terraform-aws-vpc
 ```
 
 Terrafile config file in custom directory
 ```sh
 $ terrafile -f config/Terrafile
-INFO[0000] [*] Checking out v1.46.0 of git@github.com:terraform-aws-modules/terraform-aws-vpc  
-INFO[0000] [*] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc  
+INFO[0000] [tf-aws-vpc-path] Checking out examples/simple-vpc from master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0002] [tf-aws-vpc] Checking out v1.46.0 of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0003] [tf-aws-vpc-experimental] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0005] [tf-aws-vpc-default] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0007] [tf-aws-vpc-commit] Checking out 01601169c00c68f37d5df8a80cc17c88f02c04d0 of git@github.com:terraform-aws-modules/terraform-aws-vpc
 ```
 
 Terraform modules exported to custom directory
 ```sh
 $ terrafile -p custom_directory
-INFO[0000] [*] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc  
-INFO[0001] [*] Checking out v1.46.0 of git@github.com:terraform-aws-modules/terraform-aws-vpc  
+INFO[0000] [tf-aws-vpc-path] Checking out examples/simple-vpc from master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0002] [tf-aws-vpc] Checking out v1.46.0 of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0003] [tf-aws-vpc-experimental] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0005] [tf-aws-vpc-default] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc
+INFO[0007] [tf-aws-vpc-commit] Checking out 01601169c00c68f37d5df8a80cc17c88f02c04d0 of git@github.com:terraform-aws-modules/terraform-aws-vpc
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -L https://github.com/coretech/terrafile/releases/download/v{VERSION}/terra
 ```
 
 ## How to use
-Terrafile expects a file named `Terrafile` which will contain your terraform module dependencies in a yaml like format.
+Terrafile expects a file named `Terrafile` which will contain your terraform module dependencies in a yaml format.
 
 An example Terrafile:
 ```
@@ -29,6 +29,29 @@ tf-aws-vpc:
 tf-aws-vpc-experimental:
     source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
     version: "master"
+tf-aws-vpc-default:
+    source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+tf-aws-vpc-commit:
+    source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+    commit: "01601169c00c68f37d5df8a80cc17c88f02c04d0"
+tf-aws-vpc-path:
+    source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+    path: "examples/simple-vpc"
+```
+By default, Terrafile will checkout the master branch of a module.
+
+To checkout a tag or branch use the `version` key:
+```
+tf-aws-vpc:
+    source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+    version: "v1.46.0"
+```
+
+To pin a module to a specific commit, use the `commit` key:
+```
+tf-aws-vpc-commit:
+    source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+    commit: "01601169c00c68f37d5df8a80cc17c88f02c04d0"
 ```
 
 Terrafile config file in current directory and modules exported to ./vendor/modules

--- a/main.go
+++ b/main.go
@@ -50,9 +50,9 @@ func gitClone(repository string, version string, moduleName string) {
 
 func gitClonePath(repository string, path string, version string, moduleName string) {
 	moduleDir := opts.ModulePath + "/" + moduleName
-  tmpModuleDir := opts.ModulePath + "/.tmppath_" + moduleName
+	tmpModuleDir := opts.ModulePath + "/.tmppath_" + moduleName
 
-	os.MkdirAll(tmpModuleDir + "/.git/info", os.ModePerm)
+	os.MkdirAll(tmpModuleDir+"/.git/info", os.ModePerm)
 	fh, err := os.Create(tmpModuleDir + "/.git/info/sparse-checkout")
 	if err != nil {
 		log.Fatalln(err)
@@ -79,7 +79,7 @@ func gitClonePath(repository string, path string, version string, moduleName str
 			log.Fatalln(err)
 		}
 	}
-	err = os.Rename(tmpModuleDir + "/" + path, moduleDir)
+	err = os.Rename(tmpModuleDir+"/"+path, moduleDir)
 	err = os.RemoveAll(tmpModuleDir)
 	if err != nil {
 		log.Fatalln(err)
@@ -96,7 +96,7 @@ func gitCheckoutCommit(commit string, moduleName string) {
 }
 
 func rmGit(moduleName string) {
-  gitDir := opts.ModulePath + "/" + moduleName + "/.git"
+	gitDir := opts.ModulePath + "/" + moduleName + "/.git"
 	err := os.RemoveAll(gitDir)
 	if err != nil {
 		log.Fatalln(err)

--- a/main.go
+++ b/main.go
@@ -49,9 +49,9 @@ func gitClone(repository string, version string, moduleName string) {
 }
 
 func gitClonePath(repository string, path string, version string, moduleName string) {
-  moduleDir := opts.ModulePath + "/" + moduleName
+	moduleDir := opts.ModulePath + "/" + moduleName
 
-	os.MkdirAll(moduleDir + "/.git/info", os.ModePerm)
+	os.MkdirAll(moduleDir+"/.git/info", os.ModePerm)
 	fh, err := os.Create(moduleDir + "/.git/info/sparse-checkout")
 	if err != nil {
 		log.Fatalln(err)
@@ -73,7 +73,7 @@ func gitClonePath(repository string, path string, version string, moduleName str
 
 		cmd := exec.Command(c, a...)
 		cmd.Dir = moduleDir
-		err:= cmd.Run()
+		err := cmd.Run()
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -89,13 +89,18 @@ func gitCheckoutCommit(commit string, moduleName string) {
 	}
 }
 
-func logFetch(repository string, version string, commit string, moduleName string) {
+func logFetch(repository string, version string, commit string, path string, moduleName string) {
 	var moduleVersion string
+	var pathFrom string
 	moduleVersion = version
+	pathFrom = ""
 	if commit != "" {
 		moduleVersion = commit
 	}
-	log.Printf("[%s] Checking out %s of %s", moduleName, moduleVersion, repository)
+	if path != "" {
+		pathFrom = fmt.Sprintf("%s from ", path)
+	}
+	log.Printf("[%s] Checking out %s%s of %s", moduleName, pathFrom, moduleVersion, repository)
 }
 
 func main() {
@@ -126,11 +131,11 @@ func main() {
 		if len(module.Version) == 0 {
 			module.Version = "master"
 		}
-		logFetch(module.Source, module.Version, module.Commit, key)
+		logFetch(module.Source, module.Version, module.Commit, module.Path, key)
 
 		// Checkout path or sparse checkout specified path
 		if module.Path == "" {
-		  gitClone(module.Source, module.Version, key)
+			gitClone(module.Source, module.Version, key)
 		} else {
 			gitClonePath(module.Source, module.Path, module.Version, key)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -33,8 +33,10 @@ func TestTerraformWithTerrafilePath(t *testing.T) {
 	}
 	// Assert output
 	for _, output := range []string{
-		"Checking out v1.46.0 of git@github.com:terraform-aws-modules/terraform-aws-vpc",
-		"Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc",
+		"[tf-aws-vpc] Checking out v1.46.0 of git@github.com:terraform-aws-modules/terraform-aws-vpc",
+		"[tf-aws-vpc-experimental] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc",
+		"[tf-aws-vpc-commit] Checking out 01601169c00c68f37d5df8a80cc17c88f02c04d0 of git@github.com:terraform-aws-modules/terraform-aws-vpc",
+		"[tf-aws-vpc-default] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc",
 	} {
 		assert.Contains(t, testcli.Stdout(), output)
 	}
@@ -42,6 +44,8 @@ func TestTerraformWithTerrafilePath(t *testing.T) {
 	for _, moduleName := range []string{
 		"tf-aws-vpc",
 		"tf-aws-vpc-experimental",
+		"tf-aws-vpc-commit",
+		"tf-aws-vpc-default",
 	} {
 		assert.DirExists(t, path.Join(workingDirectory, "vendor/modules", moduleName))
 	}
@@ -67,6 +71,11 @@ func createTerrafile(t *testing.T, folder string) {
 tf-aws-vpc-experimental:
   source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
   version: "master"
+tf-aws-vpc-commit:
+  source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+  commit: "01601169c00c68f37d5df8a80cc17c88f02c04d0"
+tf-aws-vpc-default:
+  source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
 `
 	createFile(t, path.Join(folder, "Terrafile"), yaml)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -37,6 +37,7 @@ func TestTerraformWithTerrafilePath(t *testing.T) {
 		"[tf-aws-vpc-experimental] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc",
 		"[tf-aws-vpc-commit] Checking out 01601169c00c68f37d5df8a80cc17c88f02c04d0 of git@github.com:terraform-aws-modules/terraform-aws-vpc",
 		"[tf-aws-vpc-default] Checking out master of git@github.com:terraform-aws-modules/terraform-aws-vpc",
+		"[tf-aws-vpc-path] Checking out examples/simple-vpc from master of git@github.com:terraform-aws-modules/terraform-aws-vpc",
 	} {
 		assert.Contains(t, testcli.Stdout(), output)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -46,6 +46,7 @@ func TestTerraformWithTerrafilePath(t *testing.T) {
 		"tf-aws-vpc-experimental",
 		"tf-aws-vpc-commit",
 		"tf-aws-vpc-default",
+		"tf-aws-vpc-path",
 	} {
 		assert.DirExists(t, path.Join(workingDirectory, "vendor/modules", moduleName))
 	}
@@ -76,6 +77,10 @@ tf-aws-vpc-commit:
   commit: "01601169c00c68f37d5df8a80cc17c88f02c04d0"
 tf-aws-vpc-default:
   source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+tf-aws-vpc-path:
+  source:  "git@github.com:terraform-aws-modules/terraform-aws-vpc"
+  path: "examples/simple-vpc"
+  version: "master"
 `
 	createFile(t, path.Join(folder, "Terrafile"), yaml)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -51,6 +51,16 @@ func TestTerraformWithTerrafilePath(t *testing.T) {
 	} {
 		assert.DirExists(t, path.Join(workingDirectory, "vendor/modules", moduleName))
 	}
+
+	for _, moduleName := range []string{
+		"tf-aws-vpc/main.tf",
+		"tf-aws-vpc-experimental/main.tf",
+		"tf-aws-vpc-commit/main.tf",
+		"tf-aws-vpc-default/main.tf",
+		"tf-aws-vpc-path/main.tf",
+	} {
+		assert.FileExists(t, path.Join(workingDirectory, "vendor/modules", moduleName))
+	}
 }
 
 func setup(t *testing.T) (current string, back func()) {


### PR DESCRIPTION
Hi 👋 

This implementation of `terrafile` works really well. I've made a few additions:
* Default to `master` if no version is specified
* Allow `commit` to be specified
* Output module name in log lines and refactor to deal with commits

Sometimes a Terraform module feature is in `master` but hasn't been tagged / released yet. Allowing a user to specify a commit sha to checkout would be helpful in these situations. 

Open to any feedback, suggestions or push back on this.