### PR TITLE
Use shallow single-branch clone, remove git indices

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/nritholtz/stdemuxerhook"
@@ -37,7 +38,7 @@ func init() {
 
 func gitClone(repository string, version string, moduleName string) {
 	log.Printf("[*] Checking out %s of %s \n", version, repository)
-	cmd := exec.Command("git", "clone", "-b", version, repository, moduleName)
+	cmd := exec.Command("git", "clone", "--single-branch", "--depth=1", "-b", version, repository, moduleName)
 	cmd.Dir = opts.ModulePath
 	err := cmd.Run()
 	if err != nil {
@@ -71,5 +72,6 @@ func main() {
 	os.MkdirAll(opts.ModulePath, os.ModePerm)
 	for key, module := range config {
 		gitClone(module.Source, module.Version, key)
+		os.RemoveAll(filepath.Join(opts.ModulePath, key, ".git"))
 	}
 }


### PR DESCRIPTION
Currently, `terrafile` performs a full clone of the remote, and leaves it as a full git repo on disk. Some downsides of this:

- When checking in vendored modules as part of another git repository, we need to manually remove the modules' `.git` indices to avoid creating sub-repositories
- Downloading more (possibly much more) data than necessary (all branches, all commits). This also just takes longer to finish (with larger repos).

The standard way of avoiding this - using `git archive` - is not supported by Github, unfortunately. Hence, this PR proposes

1) Performing a shallow clone (`--depth=1`)
2) Only cloning the single branch of interest (`--single-branch`)
3) Removing the git index of each module (`<module path>/.git`) after cloning it.

What do you think?