### PR TITLE
Implement parallel cloning

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/nritholtz/stdemuxerhook"
@@ -68,10 +69,16 @@ func main() {
 	}
 
 	// Clone modules
-	os.RemoveAll(opts.ModulePath)
-	os.MkdirAll(opts.ModulePath, os.ModePerm)
-	for key, module := range config {
-		gitClone(module.Source, module.Version, key)
-		os.RemoveAll(filepath.Join(opts.ModulePath, key, ".git"))
+	var wg sync.WaitGroup
+	_ = os.RemoveAll(opts.ModulePath)
+	_ = os.MkdirAll(opts.ModulePath, os.ModePerm)
+	for key, mod := range config {
+		wg.Add(1)
+		go func(m module, key string) {
+			gitClone(m.Source, m.Version, key)
+			_ = os.RemoveAll(filepath.Join(opts.ModulePath, key, ".git"))
+		}(mod, key)
 	}
+
+	wg.Wait()
 }

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 		go func(m module, key string) {
 			gitClone(m.Source, m.Version, key)
 			_ = os.RemoveAll(filepath.Join(opts.ModulePath, key, ".git"))
+			wg.Done()
 		}(mod, key)
 	}
 

--- a/main.go
+++ b/main.go
@@ -75,9 +75,9 @@ func main() {
 	for key, mod := range config {
 		wg.Add(1)
 		go func(m module, key string) {
+			defer wg.Done()
 			gitClone(m.Source, m.Version, key)
 			_ = os.RemoveAll(filepath.Join(opts.ModulePath, key, ".git"))
-			wg.Done()
 		}(mod, key)
 	}
 


### PR DESCRIPTION
This PR implements parallel cloning.
This means that we need to wait for all the cloning-operation to finish (doing that with the wait-group), before we exit.

The parallelisation of the cloning should give quite a speed bump if a lot of repositories are used.